### PR TITLE
releasetools: Store and use the dt image file through target files

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1701,7 +1701,7 @@ ifdef BOARD_RAMDISK_OFFSET
 	$(hide) echo "$(BOARD_RAMDISK_OFFSET)" > $(zip_root)/RECOVERY/ramdisk_offset
 endif
 ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DT)),true)
-	$(hide) echo "$(INSTALLED_DTIMAGE_TARGET)" > $(zip_root)/RECOVERY/dt_args
+	$(hide) $(ACP) $(INSTALLED_DTIMAGE_TARGET) $(zip_root)/RECOVERY/dt
 endif
 	@# Components of the boot image
 	$(hide) mkdir -p $(zip_root)/BOOT
@@ -1734,7 +1734,7 @@ ifdef BOARD_RAMDISK_OFFSET
 	$(hide) echo "$(BOARD_RAMDISK_OFFSET)" > $(zip_root)/BOOT/ramdisk_offset
 endif
 ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DT)),true)
-	$(hide) echo "$(INSTALLED_DTIMAGE_TARGET)" > $(zip_root)/BOOT/dt_args
+	$(hide) $(ACP) $(INSTALLED_DTIMAGE_TARGET) $(zip_root)/BOOT/dt
 endif
 ifdef ZIP_SAVE_UBOOTIMG_ARGS
 	$(hide) echo "$(ZIP_SAVE_UBOOTIMG_ARGS)" > $(zip_root)/BOOT/ubootargs

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -395,10 +395,10 @@ def BuildBootableImage(sourcedir, fs_config_file, info_dict=None):
       cmd.append("--ramdisk_offset")
       cmd.append(open(fn).read().rstrip("\n"))
 
-    fn = os.path.join(sourcedir, "dt_args")
+    fn = os.path.join(sourcedir, "dt")
     if os.access(fn, os.F_OK):
       cmd.append("--dt")
-      cmd.append(open(fn).read().rstrip("\n"))
+      cmd.append(fn)
 
     fn = os.path.join(sourcedir, "pagesize")
     if os.access(fn, os.F_OK):


### PR DESCRIPTION
Target files packages may be used for signing images separate from the
build process. Store the device tree image file in the target files
package so it can be used during the signing process.

Change-Id: Ie8507121fa9c4ba57ecffeab05bd859ae5f5b788
Ticket: CYNGNOS-1744